### PR TITLE
[DEBUG] Fix videoInfo for python

### DIFF
--- a/libpdraw/include/pdraw/pdraw_defs.h
+++ b/libpdraw/include/pdraw/pdraw_defs.h
@@ -119,15 +119,16 @@ typedef struct
 
 } pdraw_video_info_t;
 
+typedef union
+{
+  pdraw_video_info_t video;
+} pdraw_media_union_t;
 
 typedef struct
 {
     pdraw_media_type_t type;
     unsigned int id;
-    union
-    {
-        pdraw_video_info_t videoInfo;
-    };
+    pdraw_media_union_t info;
 
 } pdraw_media_info_t;
 

--- a/libpdraw/src/pdraw_impl.cpp
+++ b/libpdraw/src/pdraw_impl.cpp
@@ -564,13 +564,13 @@ int PdrawImpl::getMediaInfo(unsigned int index, pdraw_media_info_t *info)
     {
         case PDRAW_MEDIA_TYPE_VIDEO:
             info->type = PDRAW_MEDIA_TYPE_VIDEO;
-            info->videoInfo.type = ((VideoMedia*)media)->getVideoType();
-            ((VideoMedia*)media)->getDimensions(&info->videoInfo.width, &info->videoInfo.height,
-                &info->videoInfo.cropLeft, &info->videoInfo.cropRight,
-                &info->videoInfo.cropTop, &info->videoInfo.cropBottom,
-                &info->videoInfo.croppedWidth, &info->videoInfo.croppedHeight,
-                &info->videoInfo.sarWidth, &info->videoInfo.sarHeight);
-            ((VideoMedia*)media)->getFov(&info->videoInfo.horizontalFov, &info->videoInfo.verticalFov);
+            info->info.video.type = ((VideoMedia*)media)->getVideoType();
+            ((VideoMedia*)media)->getDimensions(&info->info.video.width, &info->info.video.height,
+                &info->info.video.cropLeft, &info->info.video.cropRight,
+                &info->info.video.cropTop, &info->info.video.cropBottom,
+                &info->info.video.croppedWidth, &info->info.video.croppedHeight,
+                &info->info.video.sarWidth, &info->info.video.sarHeight);
+            ((VideoMedia*)media)->getFov(&info->info.video.horizontalFov, &info->info.video.verticalFov);
             break;
         default:
             info->type = PDRAW_MEDIA_TYPE_UNKNOWN;


### PR DESCRIPTION
Work around for the swig issue "Nested union not currently supported"
This basically enables access to the formerly named videoInfo field from python, which includes access to horizontalFov & verticalFov, among other things.